### PR TITLE
LF for windows rules added

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     }
   },
   "rules": {
+    "linebreak-style": ["error", "windows"],
     "no-underscore-dangle": "off",
     "arrow-body-style": "off",
     "comma-dangle": "off",


### PR DESCRIPTION
 eslint in the gulp project  encountered a problem with error like this:
"Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style "   

So I have added the rules so the project can run on windows machine perfectly.